### PR TITLE
Fix importing of properties of tiles in object layers

### DIFF
--- a/pytmx/tmxloader.py
+++ b/pytmx/tmxloader.py
@@ -445,7 +445,6 @@ class TiledObjectGroup(TiledElement):
         return "<{}: \"{}\">".format(self.__class__.__name__, self.name)
 
 class TiledObject(TiledElement):
-    __slots__ = "reserved name type x y width height gid".split()
     reserved = "name type x y width height gid properties polygon polyline image".split()
 
     def __init__(self):


### PR DESCRIPTION
If a tile only appears in an object layer, its properties in the tileset were not being loaded. To fix that, I did the following:
1. Map GIDs in objects to PyTMX GIDs.
2. Load object layers before tilesets, so that the mapping exists before the tileset is loaded.
