### PR TITLE
Small mistakes in docstring samples

### DIFF
--- a/pytmx/tmxloader.py
+++ b/pytmx/tmxloader.py
@@ -109,7 +109,7 @@ Basic usage sample:
 
     >>> from pytmx import tmxloader
     >>> tmxdata = tmxloader.load_pygame("map.tmx")
-    >>> tmxdata = tmxloader.load_pygame("map.tmx", pixel_alpha=True)
+    >>> tmxdata = tmxloader.load_pygame("map.tmx", pixelalpha=True)
 
 The loader will correctly convert() or convert_alpha() each tile image, so you
 don't have to worry about that after you load the map.
@@ -118,7 +118,7 @@ don't have to worry about that after you load the map.
 When you want to draw tiles, you simply call "getTileImage":
 
     >>> image = tmxdata.getTileImage(x, y, layer)
-    >>> screen.blit(position, image)
+    >>> screen.blit(image, position)
 
 
 Maps, tilesets, layers, objectgroups, and objects all have a simple way to

--- a/pytmx/tmxloader3.py
+++ b/pytmx/tmxloader3.py
@@ -41,7 +41,7 @@ Basic usage sample:
 When you want to draw tiles, you simply call "get_tile_image":
 
     >>> image = tiledmap.get_tile_image(x, y, layer)
-    >>> screen.blit(position, image)
+    >>> screen.blit(image, position)
 
 
 Layers, objectgroups, tilesets, and maps all have a simple way to access


### PR DESCRIPTION
I am just playing around with tiled map editor. And I've been just checking Your great library (< 15min.). I've noticed some small mistakes in documentation strings (Does not work by copying/pasting).
- Wrong name of `pixelalpha` keyword argument
- Wrong positioning of `blit` arguments
