### PR TITLE
an update for TiledTileset among other things

### DIFF
--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -365,7 +365,8 @@ class TiledMap(TiledElement):
 
 
 class TiledTileset(TiledElement):
-    reserved = "firstgid source name tilewidth tileheight spacing margin image tile properties".split()
+    reserved = ("firstgid source name tilewidth tileheight width height spacing"
+    " margin image tile properties".split())
 
     def __init__(self, parent, node):
         TiledElement.__init__(self)
@@ -377,6 +378,8 @@ class TiledTileset(TiledElement):
         self.name = None
         self.tilewidth = 0
         self.tileheight = 0
+        self.width = 0
+        self.height = 0
         self.spacing = 0
         self.margin = 0
         self.tiles = {}
@@ -434,6 +437,8 @@ class TiledTileset(TiledElement):
 
         image_node = node.find('image')
         self.source = image_node.get('source')
+        self.width = int(image_node.get('width'))
+        self.height = int(image_node.get('height'))
         self.trans = image_node.get("trans", None)
 
 

--- a/pytmx/tmxloader.py
+++ b/pytmx/tmxloader.py
@@ -172,7 +172,7 @@ object:     name, type, x, y, width, height, gid, properties, polygon,
 
 Please see the TiledMap class for more api information.
 """
-from pygame import Surface, mask, RLEACCEL
+
 from utils import types
 from constants import *
 
@@ -197,7 +197,8 @@ def pygame_convert(original, colorkey, force_colorkey, pixelalpha):
 
     original is a surface and MUST NOT HAVE AN ALPHA CHANNEL
     """
-
+    from pygame import Surface, mask, RLEACCEL
+    
     tile_size = original.get_size()
 
     # count the number of pixels in the tile that are not transparent

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 """
 This is tested on pygame 1.9 and python 2.6 and 2.7.
 bitcraft (leif dot theden at gmail.com)


### PR DESCRIPTION
Hello! o/

I noticed that in order to get the size of an image we have to load the image (with pygame or SFML) and then get its size property, but I noticed that right now TMX format saves the image size along with his source:

```
 <tileset firstgid="1" name="terrain_atlas" tilewidth="32" tileheight="32">
  <image source="../maps/tilesets/terrain_atlas.png" width="1024" height="1024"/>
 </tileset>
```

So, I decided to add this changes to TiledTileset class. I also move the `import pygame` stuff because not everybody uses pygame to make games these days!

cheers!
