### PR TITLE
fix TileObject.name being overwritten if it's tile gid has properties.

### DIFF
--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -314,7 +314,6 @@ class TiledMap(TiledElement):
         for o in self.getObjects():
             p = self.getTilePropertiesByGID(o.gid)
             if p:
-                o.name = "TileObject"
                 o.__dict__.update(p)
 
 


### PR DESCRIPTION
Iterating over TiledMap.getObjects() shows that objects have their "name" property set to "TileObject" instead of the given name in the map editor. This happens only if the tile's GID has a tileset property set.

This causes issues if games rely on an object's name. 

Unit tests run OK after change.
