### PR TITLE
Fix readme name in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name="PyTMX",
         author='bitcraft',
         packages=['pytmx',],
         license = "LGPLv3",
-        long_description=read('README'),
+        long_description=read('readme.md'),
         classifiers=[
             "Intended Audience :: Developers",
             "Development Status :: 4 - Beta",


### PR DESCRIPTION
Changing the name of README to readme.md broke setup.py.
