### PR TITLE
Include install requirement of pygame

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(name="PyTMX",
         description='Map loader for TMX Files',
         author='bitcraft',
         packages=['pytmx',],
+        install_requires=['pygame'],
         license = "LGPLv3",
         long_description=read('README'),
         classifiers=[


### PR DESCRIPTION
Install fails unless pygame is already installed. This allows pip and easy_install to pull the necessary dependency.
