### PR TITLE
Adding map properties parser.

### DIFF
--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -300,6 +300,9 @@ class TiledMap(TiledElement):
         self.imagemap[(0, 0)] = 0
 
         self.background_color = etree.get('backgroundcolor', self.background_color)
+        
+        # parse map properties
+        self.map_properties = parse_properties(etree)
 
         # *** do not change this load order!  gid mapping errors will occur if changed ***
         for node in etree.findall('layer'):


### PR DESCRIPTION
Line added to read map properties from Tiled. They are created in Map>Map Properties and they were parsed by your code. It can work fine.
