### PR TITLE
Changed the pyglet example to better reflect the engine

### DIFF
--- a/apps/test_pyglet.py
+++ b/apps/test_pyglet.py
@@ -32,8 +32,8 @@ class TiledRenderer(object):
         tm = load_pyglet(filename)
         self.size = tm.width * tm.tilewidth, tm.height * tm.tileheight
         self.tmx_data = tm
-        self.batches = []
-        self.sprites = []
+        self.batches = []   # list of batches, e.g. layers
+        self.sprites = []   # container for tiles
         self.generate_sprites()
 
     def draw_rect(self, color, rect, width):
@@ -54,8 +54,8 @@ class TiledRenderer(object):
         poly_color = (0, 255, 0)
 
         for layer in self.tmx_data.visible_layers:
-            batch = pyglet.graphics.Batch()
-            self.batches.append(batch)
+            batch = pyglet.graphics.Batch() # create a new batch
+            self.batches.append(batch)      # add the batch to the list
             # draw map tile layers
             if isinstance(layer, TiledTileLayer):
 
@@ -92,7 +92,7 @@ class TiledRenderer(object):
             # draw image layers
             elif isinstance(layer, TiledImageLayer):
                 if layer.image:
-                    x = mw // 2
+                    x = mw // 2  # centers image
                     y = mh // 2
                     sprite = pyglet.sprite.Sprite(
                         layer.image, batch=batch, x=x, y=y
@@ -100,9 +100,8 @@ class TiledRenderer(object):
                     self.sprites.append(sprite)
 
     def draw(self):
-        if self.batches:
-            for b in self.batches:
-                b.draw()
+        for b in self.batches:
+            b.draw()
 
 
 class SimpleTest(object):

--- a/apps/test_pyglet.py
+++ b/apps/test_pyglet.py
@@ -21,6 +21,7 @@ from pytmx import *
 from pytmx.util_pyglet import load_pyglet
 import pyglet
 
+
 class TiledRenderer(object):
     """
     Super simple way to render a tiled map with pyglet
@@ -44,8 +45,8 @@ class TiledRenderer(object):
     def generate_sprites(self):
         tw = self.tmx_data.tilewidth
         th = self.tmx_data.tileheight
-        mh = self.tmx_data.height - 1
         mw = self.tmx_data.width
+        mh = self.tmx_data.height - 1
         draw_rect = self.draw_rect
         draw_lines = self.draw_lines
 


### PR DESCRIPTION
In my game, I achieved great performance when I used batches for layers and sprites for tiles when importing tiled maps, so I changed the example to use that method instead. Thanks again for the work you've put into this.