### PR TITLE
Add basic tile animation support

### DIFF
--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -781,7 +781,7 @@ class TiledTileset(TiledElement):
 
             # handle tiles with animations
             anim = child.find('animation')
-            p['frames'] = []
+            p['frames'] = list()
             if anim is not None:
                 for frame in anim.findall("frame"):
                     f = dict()

--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -300,7 +300,6 @@ class TiledMap(TiledElement):
 
         # iterate through tile objects and handle the image
         for o in [o for o in self.objects if o.gid]:
-
             # gids might also have properties assigned to them
             # in that case, assign the gid properties to the object as well
             p = self.get_tile_properties_by_gid(o.gid)
@@ -505,8 +504,8 @@ class TiledMap(TiledElement):
         # use this func to make sure GID is valid
         self.get_tile_image_by_gid(gid)
 
-        p = product(range(self.width),
-                    range(self.height),
+        p = product(range(int(self.width)),
+                    range(int(self.height)),
                     range(len(self.layers)))
 
         return ((x, y, l) for (x, y, l) in p if
@@ -779,6 +778,17 @@ class TiledTileset(TiledElement):
                 p['trans'] = image.get('trans', None)
                 p['width'] = image.get('width')
                 p['height'] = image.get('height')
+
+            # handle tiles with animations
+            anim = child.find('animation')
+            p['frames'] = []
+            if anim is not None:
+                for frame in anim.findall("frame"):
+                    f = dict()
+                    f['duration'] = int(frame.attrib['duration'])
+                    f['tileid'] = int(frame.attrib['tileid'])
+                    p['frames'].append(f)
+                    self.parent.register_gid(f['tileid'])
 
             for gid, flags in self.parent.map_gid(tiled_gid + self.firstgid):
                 self.parent.set_tile_properties(gid, p)


### PR DESCRIPTION
This pull request adds some basic tile attributes that makes animation support possible with PyTMX. Some helper functions might be useful to make it easier for people to use animations in the future. If there's any changes needed for this pull request to be accepted or if you were thinking of implementing this differently, let me know. This change will work with all rendering engines and not break current compatibility. 

Here's some example images of tile animations working in my project with this change:

**Tiled Map Editor**
![](http://i.imgur.com/T5O3I0V.gif)
**In-game**
![](http://i.imgur.com/3Qk0MdO.gif)

Here's how I used these new tile properties in my project to implement animations in Pygame:

```python
# Check to see if this tile has an animation
tile_gid = tmxdata.get_tile_gid(x, y, layer)
tile_properties = tmxdata.get_tile_properties(x, y, layer)
if tile_properties and "frames" in tile_properties:
    images_and_durations = []
    for frame in tile_properties["frames"]:
        gid = tmxdata.gidmap[frame["tileid"] + tile_gid][0][0]
        anim_surface = tmxdata.get_tile_image_by_gid(gid)
        images_and_durations.append((anim_surface, float(frame["duration"]) / 1000))
    surface = PygAnimation(images_and_durations)
    surface.play()
```