### PR TITLE
Fix bug with animations where mapping would only work if a single tileset was used. 

### DIFF
--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -797,8 +797,8 @@ class TiledTileset(TiledElement):
                     f = dict()
                     f['duration'] = int(frame.attrib['duration'])
                     f['tileid'] = int(frame.attrib['tileid'])
+                    f['gid'] = self.parent.register_gid(f['tileid'] + self.firstgid)
                     p['frames'].append(f)
-                    self.parent.register_gid(f['tileid'])
 
             for gid, flags in self.parent.map_gid(tiled_gid + self.firstgid):
                 self.parent.set_tile_properties(gid, p)


### PR DESCRIPTION
This pull request fixes a bug where animations would only work if a single tileset was used in the map (sorry, should have more thoroughly tested). I also added a "gid" property to make it easy to get an animation frame by gid.

Now tile animations can be done with this code when looping through each tile layer:

```python
# Check to see if this tile has an animation
tile_properties = tmxdata.get_tile_properties(x, y, layer)
if tile_properties and "frames" in tile_properties:
    images_and_durations = list()
    for frame in tile_properties["frames"]:
        gid = frame["gid"]
        anim_surface = tmxdata.get_tile_image_by_gid(gid)
        images_and_durations.append((anim_surface, float(frame["duration"]) / 1000))
    surface = PygAnimation(images_and_durations)
    surface.play()
```