### PR TITLE
Fixed object's properties being overwritten by tile ones

### DIFF
--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -406,7 +406,8 @@ class TiledMap(TiledElement):
             # in that case, assign the gid properties to the object as well
             p = self.get_tile_properties_by_gid(o.gid)
             if p:
-                o.properties.update(p)
+                for key in p:
+                    o.properties.setdefault(key, p[key])
 
             if self.invert_y:
                 o.y -= o.height


### PR DESCRIPTION
According to [Tiled docs](http://doc.mapeditor.org/en/latest/manual/custom-properties/#tile-property-inheritance) object's properties should inherit tile ones. Before this PR PyTMX acts otherwise - overwrites object properties with the default ones from tiles (which are named the same).