### PR TITLE
#91 - Parse property types

### DIFF
--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -27,6 +27,7 @@ from collections import defaultdict, namedtuple
 from itertools import chain, product
 from operator import attrgetter
 from xml.etree import ElementTree
+import importlib
 
 import six
 from six.moves import map
@@ -201,7 +202,14 @@ def parse_properties(node):
     d = dict()
     for child in node.findall('properties'):
         for subnode in child.findall('property'):
-            d[subnode.get('name')] = subnode.get('value')
+            cls = None
+            try:
+                if "type" in subnode.keys():
+                    module = importlib.import_module('builtins')
+                    cls = getattr(module, subnode.get("type"))
+            except AttributeError:
+                logger.info("Type [} Not a built-in type. Defaulting to string-cast.")
+            d[subnode.get('name')] = cls(subnode.get('value')) if cls is not None else subnode.get('value')
     return d
 
 

--- a/tests/test01.tmx
+++ b/tests/test01.tmx
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map version="1.0" orientation="orthogonal" renderorder="right-down" width="15" height="15" tilewidth="16" tileheight="16" backgroundcolor="#000000" nextobjectid="9">
+<map version="1.0" tiledversion="1.1.5" orientation="orthogonal" renderorder="right-down" width="15" height="15" tilewidth="16" tileheight="16" infinite="0" backgroundcolor="#000000" nextobjectid="9">
  <properties>
-  <property name="custom0" value="value"/>
-  <property name="custom1" value="value"/>
-  <property name="custom2" value="value"/>
+  <property name="test_bool" type="bool" value="true"/>
+  <property name="test_color" type="color" value="#ffff0000"/>
+  <property name="test_file" type="file" value="tileset.png"/>
+  <property name="test_float" type="float" value="37"/>
+  <property name="test_int" type="int" value="5"/>
+  <property name="test_string" value="hello, bitcraft!"/>
  </properties>
- <tileset firstgid="1" name="tileset" tilewidth="16" tileheight="16">
+ <tileset firstgid="1" name="tileset" tilewidth="16" tileheight="16" tilecount="336" columns="16">
   <properties>
    <property name="overworld" value="test"/>
   </properties>
@@ -31,7 +34,7 @@
    </properties>
   </tile>
  </tileset>
- <tileset firstgid="337" name="tiles" tilewidth="32" tileheight="32">
+ <tileset firstgid="337" name="tiles" tilewidth="32" tileheight="32" tilecount="80" columns="8">
   <image source="tileset.png" width="256" height="336"/>
  </tileset>
  <layer name="Grass and Water" width="15" height="15">
@@ -63,7 +66,7 @@
    <polyline points="0,0 112,0 128,-16 160,-16 240,-96"/>
   </object>
   <object id="4" name="GenericObject" x="96" y="64" width="32" height="32"/>
-  <object id="5" name="SandCave" gid="262" x="64" y="80"/>
+  <object id="5" name="SandCave" gid="262" x="64" y="80" width="16" height="16"/>
   <object id="6" name="Road" x="224" y="48">
    <properties>
     <property name="MoveCost" value="2"/>
@@ -73,9 +76,9 @@
   <object id="7" x="32" y="16" rotation="90.5">
    <polygon points="0,0 9.66667,-8.66667 18,-15.6667 25,-16.3333 34.6667,-9.66667 42.6667,1 39,4.33333 40.3333,7.66667 39.3333,11.3333 24.6667,12.6667 16.6667,11 15.3333,7 4.33333,8 0.333333,3.33333"/>
   </object>
-  <object id="8" name="large tile object" gid="338" x="96" y="96"/>
+  <object id="8" name="large tile object" gid="338" x="96" y="96" width="32" height="32"/>
  </objectgroup>
  <imagelayer name="Image Layer 1" visible="0">
-  <image source="tileset.png"/>
+  <image source="tileset.png" width="256" height="336"/>
  </imagelayer>
 </map>

--- a/tests/test_pytmx.py
+++ b/tests/test_pytmx.py
@@ -51,6 +51,14 @@ class TiledMapTest(TestCase):
     def test_import_pytmx_doesnt_import_pygame(self):
         self.assertTrue('pygame' not in sys.modules)
 
+    def test_properties_are_converted_to_builtin_types(self):
+        self.assertIsInstance(self.m.properties['test_bool'], bool)
+        self.assertIsInstance(self.m.properties['test_color'], str)
+        self.assertIsInstance(self.m.properties['test_file'], str)
+        self.assertIsInstance(self.m.properties['test_float'], float)
+        self.assertIsInstance(self.m.properties['test_int'], int)
+        self.assertIsInstance(self.m.properties['test_string'], str)
+
 
 class handle_bool_TestCase(TestCase):
     def test_when_passed_true_it_should_return_true(self):


### PR DESCRIPTION
Properties are parsed to builtin types
 - int
 - float
 - string
 - bool

 color and file are defaulted back to string

Furthermore I removed the three old custom properties and added new ones to the test map. 
Added a unittest which runs through.