### PR TITLE
Add text files to source distribution.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include LICENSE
+include changelog
+include readme.md
+recursive-include apps
+recursive-include docs
+recursive-include tests


### PR DESCRIPTION
Most importantly, LGPL requires the licence text to be shipped with the source tarball!

Found during packaging for Debian.