### PR TITLE
Fix image source for external tilesets

### DIFF
--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -891,7 +891,7 @@ class TiledTileset(TiledElement):
             
             # images are listed as relative to the .tsx file, not the .tmx file:
             if source and "path" in p:
-                    p["path"] = os.path.join(os.path.dirname(source), p["path"])
+                p["path"] = os.path.join(os.path.dirname(source), p["path"])
 
             # handle tiles that have their own image
             image = child.find('image')
@@ -899,7 +899,11 @@ class TiledTileset(TiledElement):
                 p['width'] = self.tilewidth
                 p['height'] = self.tileheight
             else:
-                p['source'] = image.get('source')
+                tile_source = image.get('source')
+                # images are listed as relative to the .tsx file, not the .tmx file:
+                if tile_source: 
+                    tile_source = os.path.join(os.path.dirname(source), tile_source)
+                p['source'] = tile_source
                 p['trans'] = image.get('trans', None)
                 p['width'] = image.get('width')
                 p['height'] = image.get('height')


### PR DESCRIPTION
This fixes #108 and allows external tilesets to be located in a different directory than the .tmx file ; previously to this commit tile images were incorrectly loaded from a path relative to the .tmx file.
See also #103, which solved the same problem but is now incompatible with the latest versions of Tiled.