### PR TITLE
Change license headers from GPLv3+ to LGPLv3+.

### DIFF
--- a/pytmx/__init__.py
+++ b/pytmx/__init__.py
@@ -5,17 +5,17 @@ Copyright (C) 2012-2017, Leif Theden <leif.theden@gmail.com>
 This file is part of pytmx.
 
 pytmx is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
 
 pytmx is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public
+License along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
 """
 import logging
 

--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -5,17 +5,17 @@ Copyright (C) 2012-2017, Leif Theden <leif.theden@gmail.com>
 This file is part of pytmx.
 
 pytmx is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
 
 pytmx is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public
+License along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/pytmx/util_pygame.py
+++ b/pytmx/util_pygame.py
@@ -5,17 +5,17 @@ Copyright (C) 2012-2017, Leif Theden <leif.theden@gmail.com>
 This file is part of pytmx.
 
 pytmx is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
 
 pytmx is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public
+License along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/pytmx/util_pyglet.py
+++ b/pytmx/util_pyglet.py
@@ -5,17 +5,17 @@ Copyright (C) 2012-2017, Leif Theden <leif.theden@gmail.com>
 This file is part of pytmx.
 
 pytmx is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
 
 pytmx is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public
+License along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/pytmx/util_pysdl2.py
+++ b/pytmx/util_pysdl2.py
@@ -5,17 +5,17 @@ Copyright (C) 2012-2017, Leif Theden <leif.theden@gmail.com>
 This file is part of pytmx.
 
 pytmx is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
 
 pytmx is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+GNU Lesser General Public License for more details.
 
-You should have received a copy of the GNU General Public License
-along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the GNU Lesser General Public
+License along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
 """
 from __future__ import absolute_import
 from __future__ import division


### PR DESCRIPTION
This reconciles the toplevel LICENSE, README and metadata in setup.py
(which list LGPLv3+) with the license headers in the files (prior to
this change GPLv3+).  This was acknowledged by bitcraft, the author, as
the correct license here:
https://github.com/bitcraft/PyTMX/issues/105#issuecomment-422178504

Fixes #105