### PR TITLE
Fix crash when source path of tile image is empty

### DIFF
--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -901,7 +901,7 @@ class TiledTileset(TiledElement):
             else:
                 tile_source = image.get('source')
                 # images are listed as relative to the .tsx file, not the .tmx file:
-                if tile_source: 
+                if source:
                     tile_source = os.path.join(os.path.dirname(source), tile_source)
                 p['source'] = tile_source
                 p['trans'] = image.get('trans', None)


### PR DESCRIPTION
I ran the test_pyglet.py demo included in the repo an noticed a crash on the "embed_tile_image.tmx" example.

I'm not sure why "tile_source" was checked before, i guess is was a mistake and "source" should be checked.

Now the example renders just fine.