### PR TITLE
Shut down more gracefully when an unsupported "infinite" TMX map is loaded

### DIFF
--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -1014,6 +1014,11 @@ class TiledTileLayer(TiledElement):
         data = None
         next_gid = None
         data_node = node.find('data')
+        chunk_nodes = data_node.findall('chunk')
+        if chunk_nodes:
+            msg = 'TMX map size: infinite is not supported.'
+            logger.error(msg)
+            raise Exception
 
         encoding = data_node.get('encoding', None)
         if encoding == 'base64':


### PR DESCRIPTION
This patch does not fix #94 but at least gives a clear error message what is happening.