### PR TITLE
Restore import of BytesIO in pytmx/pytmx.py

### DIFF
--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -20,6 +20,7 @@ License along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
 import logging
 import os
 from collections import defaultdict, namedtuple
+from io import BytesIO
 from itertools import chain, product
 from operator import attrgetter
 from xml.etree import ElementTree


### PR DESCRIPTION
I needed to make this change in order to get pygame_demo.py to run.  Without it I got the following error:

$ python pygame_demo.py
pygame 2.0.0 (SDL 2.0.12, python 3.9.0)
Hello from the pygame community. https://www.pygame.org/contribute.html
INFO:__main__:(3, 23, 1)
INFO:__main__:Testing data\desert.tmx
Traceback (most recent call last):
  File "C:\Users\User\Desktop\pytmx\apps\pygame_demo.py", line 240, in <module>
    if not SimpleTest(filename).run():
  File "C:\Users\User\Desktop\pytmx\apps\pygame_demo.py", line 141, in __init__
    self.load_map(filename)
  File "C:\Users\User\Desktop\pytmx\apps\pygame_demo.py", line 146, in load_map
    self.renderer = TiledRenderer(filename)
  File "C:\Users\User\Desktop\pytmx\apps\pygame_demo.py", line 45, in __init__
    tm = load_pygame(filename)
  File "C:\Users\User\AppData\Local\Programs\Python\Python39\lib\site-packages\pytmx-3.23.1-py3.9.egg\pytmx\util_pygame.py", line 140, in load_pygame
  File "C:\Users\User\AppData\Local\Programs\Python\Python39\lib\site-packages\pytmx-3.23.1-py3.9.egg\pytmx\pytmx.py", line 349, in __init__
  File "C:\Users\User\AppData\Local\Programs\Python\Python39\lib\site-packages\pytmx-3.23.1-py3.9.egg\pytmx\pytmx.py", line 380, in parse_xml
  File "C:\Users\User\AppData\Local\Programs\Python\Python39\lib\site-packages\pytmx-3.23.1-py3.9.egg\pytmx\pytmx.py", line 961, in __init__
  File "C:\Users\User\AppData\Local\Programs\Python\Python39\lib\site-packages\pytmx-3.23.1-py3.9.egg\pytmx\pytmx.py", line 1037, in parse_xml
NameError: name 'BytesIO' is not defined