### PR TITLE
Fix property parsing to support multi-line strings

### DIFF
--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -203,13 +203,13 @@ def parse_properties(node):
     d = dict()
     for child in node.findall('properties'):
         for subnode in child.findall('property'):
-            cls = None
+            cls = str
             try:
                 if "type" in subnode.keys():
                     cls = prop_type[subnode.get("type")]
             except AttributeError:
                 logger.info("Type {} Not a built-in type. Defaulting to string-cast.".format(subnode.get("type")))
-            d[subnode.get('name')] = cls(subnode.get('value')) if cls is not None else subnode.get('value')
+            d[subnode.get('name')] = cls(subnode.get('value', subnode.text))
     return d
 
 


### PR DESCRIPTION
As of Tiled 1.4.1, multi-line string properties are stored in the body of the XML node instead of as an attribute:

```
   <property name="test_long_string">test

string</property>
```

Therefore, default to .text on the node if the value attribute isn't present.

This doesn't seem to happen under any other circumstance:

```
<?xml version="1.0" encoding="UTF-8"?>
<tileset version="1.4" tiledversion="1.4.1" name="testing" tilewidth="32" tileheight="32" tilecount="1" columns="1">
 <image source="testing.png" width="32" height="32"/>
 <tile id="1">
  <properties>
   <property name="test_bool" type="bool" value="true"/>
   <property name="test_color" type="color" value="#ff4580c8"/>
   <property name="test_file" type="file" value="testing.txt"/>
   <property name="test_float" type="float" value="1.2"/>
   <property name="test_int" type="int" value="5"/>
   <property name="test_long_string">test

string</property>
   <property name="test_object" type="object" value="0"/>
   <property name="test_string" value="asdf"/>
  </properties>
 </tile>
</tileset>
```