### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Getting Help
 ============
 
 For bugs or feature requests, please use the issues feature of github.  For
-all other general questions, join me on IRC at freennode.net #pygame.
+all other general questions, join me on IRC at freenode.net #pygame.
 
 
 Installation

--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -343,7 +343,7 @@ class TiledMap(TiledElement):
         :param optional_gids: load specific tile image GID, even if never used
         :param invert_y: invert the y axis
         :param load_all_tiles: load all tile images, even if never used
-        :param allow_duplicate_names: allow duplicates in objects' metatdata
+        :param allow_duplicate_names: allow duplicates in objects' metadata
 
         image_loader:
           this must be a reference to a function that will accept a tuple:

--- a/pytmx/util_pygame.py
+++ b/pytmx/util_pygame.py
@@ -54,7 +54,7 @@ def smart_convert(original, colorkey, pixelalpha):
     if colorkey:
         tile = original.convert()
         tile.set_colorkey(colorkey, pygame.RLEACCEL)
-        # TODO: if there is a colorkey, count the colorkey pixels to determine if RLEACCEL sould be used
+        # TODO: if there is a colorkey, count the colorkey pixels to determine if RLEACCEL should be used
 
     # no colorkey, so use a mask to determine if there are transparent pixels
     else:

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ Getting Help
 ===============================================================================
 
 For bugs or feature requests, please use the issues feature of github.  For
-all other general questions, join me on IRC at freennode.net #pygame.
+all other general questions, join me on IRC at freenode.net #pygame.
 
 
 Design Goals and Features
@@ -361,7 +361,7 @@ Pytmx loads tile layers and their data:
 #### Tile Images
 
 Single tile images are accessible from TiledMap, TiledTileLayer, and TiledObject objects.
-If you requre all images in a layer, there are more effecient ways described below.
+If you requre all images in a layer, there are more efficient ways described below.
 
 ```python
 # get image from the TiledMap using x, y, and layer numbers
@@ -445,7 +445,7 @@ Working with Objects
 ===============================================================================
 
 Tiled "objects" are things that are created in object layers, and include
-polygons, polylings, boxes, ellispes, and tile objects.  Pytmx loads all objects
+polygons, polylings, boxes, ellipses, and tile objects.  Pytmx loads all objects
 and their data:
 
 - name


### PR DESCRIPTION
There are small typos in:
- docs/index.rst
- pytmx/pytmx.py
- pytmx/util_pygame.py
- readme.md

Fixes:
- Should read `freenode` rather than `freennode`.
- Should read `metadata` rather than `metatdata`.
- Should read `ellipses` rather than `ellispes`.
- Should read `efficient` rather than `effecient`.
- Should read `should` rather than `sould`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md