### PR TITLE
track groups, find layers inside groups

### DIFF
--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -430,21 +430,24 @@ class TiledMap(TiledElement):
 
         # ***         do not change this load order!         *** #
         # ***    gid mapping errors will occur if changed    *** #
-        for subnode in node.findall('layer'):
+        for subnode in node.findall('.//group'):
+            self.add_layer(TiledGroupLayer(self, subnode))
+
+        for subnode in node.findall('.//layer'):
             self.add_layer(TiledTileLayer(self, subnode))
 
-        for subnode in node.findall('imagelayer'):
+        for subnode in node.findall('.//imagelayer'):
             self.add_layer(TiledImageLayer(self, subnode))
 
         # this will only find objectgroup layers, not including tile colliders
-        for subnode in node.findall('objectgroup'):
+        for subnode in node.findall('.//objectgroup'):
             objectgroup = TiledObjectGroup(self, subnode)
             self.add_layer(objectgroup)
             for obj in objectgroup:
                 self.objects_by_id[obj.id] = obj
                 self.objects_by_name[obj.name] = obj
 
-        for subnode in node.findall('tileset'):
+        for subnode in node.findall('.//tileset'):
             self.add_tileset(TiledTileset(self, subnode))
 
         # "tile objects", objects with a GID, require their attributes to be
@@ -704,9 +707,8 @@ class TiledMap(TiledElement):
 
         :param layer: TileTileLayer, TiledImageLayer, TiledObjectGroup object
         """
-        assert (
-            isinstance(layer,
-                       (TiledTileLayer, TiledImageLayer, TiledObjectGroup)))
+        assert (isinstance(layer, (TiledGroupLayer, TiledTileLayer,
+                                   TiledImageLayer, TiledObjectGroup)))
 
         self.layers.append(layer)
         self.layernames[layer.name] = layer
@@ -808,7 +810,7 @@ class TiledMap(TiledElement):
         :rtype: Iterator
         """
         return (i for (i, l) in enumerate(self.layers)
-                if l.visible and isinstance(l, TiledTileLayer))
+                if isinstance(l, TiledTileLayer) and l.visible)
 
     @property
     def visible_object_groups(self):
@@ -1006,6 +1008,19 @@ class TiledTileset(TiledElement):
             self.width = int(image_node.get('width'))
             self.height = int(image_node.get('height'))
 
+        return self
+
+
+class TiledGroupLayer(TiledElement):
+    def __init__(self, parent, node):
+        TiledElement.__init__(self)
+        self.parent = parent
+        self.name = None
+        self.parse_xml(node)
+
+    def parse_xml(self, node):
+        self._set_properties(node)
+        self.name = node.get('name', None)
         return self
 
 

--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -810,7 +810,7 @@ class TiledMap(TiledElement):
         :rtype: Iterator
         """
         return (i for (i, l) in enumerate(self.layers)
-                if isinstance(l, TiledTileLayer) and l.visible)
+                if l.visible and isinstance(l, TiledTileLayer))
 
     @property
     def visible_object_groups(self):
@@ -1016,6 +1016,7 @@ class TiledGroupLayer(TiledElement):
         TiledElement.__init__(self)
         self.parent = parent
         self.name = None
+        self.visible = 1
         self.parse_xml(node)
 
     def parse_xml(self, node):


### PR DESCRIPTION
First off, I love pytmx. Been using it forever and it's awesome. much ❤️ 

lmk if this is something that's needed. In a lot of cases, I'd find this useful and I noticed an issue (cited below) echoing the same. This PR is an initial attempt to track groups and parse the layers within them.

Changes:

- tile layers (and every other layer type) are found, not just those at the root
- you can find a group with get_layer_by_name as an issue pointed out did not return groups #124 
- new layer type: TiledGroupLayer

Tested with:
- empty, populated, and nested group layers in tiled locally
- passed unittests

The group layer object I implemented is pretty rudimentary, idk if we want it to contain a list of layers inside or transitively pass `visible` from groups to layers. I figured with feedback I could add that if we want to continue down this route. Or this is complete garbage and we can just close 😄 