### PR TITLE
basic CI + target version bump to 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,18 @@ jobs:
           - 3.7.12
           - 3.8.12
           - 3.9.7
+        dependencies:
+          - pygame pyglet
+          - pygame
+          - pyglet
+          - "null"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Requirements
-        run: pip install -r requirements.txt
+        if: ${{ matrix.dependencies != "null" }}
+        run: pip install ${{ matrix.dependencies }}
       - name: Run Tests
         run: python -m unittest tests/pytmx/test_pytmx.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Requirements
-        if: ${{ matrix.dependencies != "null" }}
+        if: ${{ matrix.dependencies != 'null' }}
         run: pip install ${{ matrix.dependencies }}
       - name: Run Tests
         run: python -m unittest tests/pytmx/test_pytmx.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,18 @@ on:
 jobs:
   test:
     runs-on: [ubuntu-latest]
+    strategy:
+      matrix:
+        python-version:
+          - 3.3.7
+          - 3.6.15
+          - 3.8.12
+          - 3.9.7
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.python-version }}
       - name: Install Requirements
         run: pip install -r requirements.txt
       - name: Run Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.3.7
+          - 3.5.10
           - 3.6.15
           - 3.8.12
           - 3.9.7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8"
+      - name: Install Requirements
+        run: pip install -r requirements.txt
+      - name: Run Tests
+        run: python -m unittest tests/pytmx/test_pytmx.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.5.10
-          - 3.6.15
+          - 3.7.12
           - 3.8.12
           - 3.9.7
     steps:

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 ## PyTMX
-##### For Python 3.3+
+##### For Python 3.7+
 
 If you have any problems or suggestions, please open an issue.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-pygame==2.0.1
-dataclasses==0.6
-pyglet==1.5.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pygame==2.0.1
+dataclasses==0.6
+pyglet==1.5.21

--- a/tests/pytmx/test_pytmx.py
+++ b/tests/pytmx/test_pytmx.py
@@ -73,11 +73,14 @@ class TiledMapTest(unittest.TestCase):
         self.m = pytmx.TiledMap(self.filename)
 
     def test_build_rects(self):
-        from pytmx import util_pygame
-        rects = util_pygame.build_rects(self.m, "Grass and Water", "tileset", None)
-        self.assertEqual(rects[0], [0, 0, 240, 240])
-        rects = util_pygame.build_rects(self.m, "Grass and Water", "tileset", 18)
-        self.assertNotEqual(0, len(rects))
+        try:
+            from pytmx import util_pygame
+            rects = util_pygame.build_rects(self.m, "Grass and Water", "tileset", None)
+            self.assertEqual(rects[0], [0, 0, 240, 240])
+            rects = util_pygame.build_rects(self.m, "Grass and Water", "tileset", 18)
+            self.assertNotEqual(0, len(rects))
+        except ImportError:
+            pass
 
     def test_get_tile_image(self):
         image = self.m.get_tile_image(0, 0, 0)

--- a/tests/pytmx/test_pytmx.py
+++ b/tests/pytmx/test_pytmx.py
@@ -67,7 +67,7 @@ class TestConvertToBool(unittest.TestCase):
 
 
 class TiledMapTest(unittest.TestCase):
-    filename = '../resources/test01.tmx'
+    filename = 'tests/resources/test01.tmx'
 
     def setUp(self):
         self.m = pytmx.TiledMap(self.filename)


### PR DESCRIPTION
Yo, I was in the neighborhood again. I didn't see any public CI so I added a basic workflow to run the tests against a few python versions. While doing so, to my understanding, these things stood out:

- [this line with an f-string](https://github.com/bitcraft/pytmx/blob/master/pytmx/pytmx.py#L117) prevents any python version <3.6 from working
- [this line with a future import](https://github.com/bitcraft/pytmx/blob/master/pytmx/pytmx.py#L20) prevents any python version <3.7 from working

so I bumped up the target version in the readme

lmk if I misunderstood anything about this or if y'all already have private CI!