### PR TITLE
Fix layer by name typehint

### DIFF
--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -507,7 +507,7 @@ class TiledMap(TiledElement):
         self.layers = list()  # all layers in proper order
         self.tilesets = list()  # TiledTileset objects
         self.tile_properties = dict()  # tiles that have properties
-        self.layernames = dict()
+        self.layers_by_name = dict()
         self.objects_by_id = dict()
         self.objects_by_name = dict()
 
@@ -934,7 +934,7 @@ class TiledMap(TiledElement):
         )
 
         self.layers.append(layer)
-        self.layernames[layer.name] = layer
+        self.layers_by_name[layer.name] = layer
 
     def add_tileset(self, tileset: TiledTileset) -> None:
         """Add a tileset to the map."""
@@ -955,7 +955,7 @@ class TiledMap(TiledElement):
 
         """
         try:
-            return self.layernames[name]
+            return self.layers_by_name[name]
         except KeyError:
             msg = 'Layer "{0}" not found.'
             logger.debug(msg.format(name))

--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -19,7 +19,6 @@ License along with pytmx.  If not, see <https://www.gnu.org/licenses/>.
 """
 from __future__ import annotations
 
-
 import gzip
 import logging
 import os
@@ -68,7 +67,6 @@ GID_TRANS_FLIPX = 1 << 31
 GID_TRANS_FLIPY = 1 << 30
 GID_TRANS_ROT = 1 << 29
 GID_MASK = GID_TRANS_FLIPX | GID_TRANS_FLIPY | GID_TRANS_ROT
-
 
 # error message format strings go here
 duplicate_name_fmt = (
@@ -148,7 +146,7 @@ def reshape_data(
         List[List[int]]: 2D nested list object.
 
     """
-    return [gids[i : i + width] for i in range(0, len(gids), width)]
+    return [gids[i:i + width] for i in range(0, len(gids), width)]
 
 
 def unpack_gids(
@@ -1119,8 +1117,8 @@ class TiledMap(TiledElement):
             return 0
 
     def register_gid_check_flags(
-            self,
-            tiled_gid: int,
+        self,
+        tiled_gid: int,
     ) -> int:
         """Used to manage the mapping of GIDs between .tmx and pytmx.
 

--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -939,14 +939,16 @@ class TiledMap(TiledElement):
         assert isinstance(tileset, TiledTileset)
         self.tilesets.append(tileset)
 
-    def get_layer_by_name(self, name: str) -> int:
+    def get_layer_by_name(self, name: str) -> Union[
+        TiledTileLayer, TiledImageLayer, TiledGroupLayer, TiledObjectGroup
+    ]:
         """Return a layer by name.
 
         Args:
             name (str): The layer's name. Case-sensitive!
 
         Returns:
-            int: The layer number.
+            Union[TiledTileLayer, TiledImageLayer, TiledGroupLayer, TiledObjectGroup]: The layer.
 
         Raises:
             ValueError: if layer by name does not exist

--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -81,6 +81,7 @@ TileFlags = namedtuple("TileFlags", flag_names)
 empty_flags = TileFlags(False, False, False)
 ColorLike = Union[Tuple[int, int, int, int], Tuple[int, int, int], int, str]
 MapPoint = Tuple[int, int, int]
+TiledLayer = Union["TiledTileLayer", "TiledImageLayer", "TiledGroupLayer", "TiledObjectGroup"]
 
 # need a more graceful way to handle annotations for optional dependencies
 if pygame:
@@ -917,14 +918,12 @@ class TiledMap(TiledElement):
 
     def add_layer(
         self,
-        layer: Union[
-            TiledTileLayer, TiledImageLayer, TiledGroupLayer, TiledObjectGroup
-        ],
+        layer: TiledLayer,
     ) -> None:
         """Add a layer to the map.
 
         Args:
-            layer (Union[TiledTileLayer, TiledImageLayer, TiledGroupLayer, TiledObjectGroup]): The layer.
+            layer (TiledLayer): The layer.
 
         """
         assert isinstance(
@@ -939,16 +938,14 @@ class TiledMap(TiledElement):
         assert isinstance(tileset, TiledTileset)
         self.tilesets.append(tileset)
 
-    def get_layer_by_name(self, name: str) -> Union[
-        TiledTileLayer, TiledImageLayer, TiledGroupLayer, TiledObjectGroup
-    ]:
+    def get_layer_by_name(self, name: str) -> TiledLayer:
         """Return a layer by name.
 
         Args:
             name (str): The layer's name. Case-sensitive!
 
         Returns:
-            Union[TiledTileLayer, TiledImageLayer, TiledGroupLayer, TiledObjectGroup]: The layer.
+            TiledLayer: The layer.
 
         Raises:
             ValueError: if layer by name does not exist

--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -81,7 +81,9 @@ TileFlags = namedtuple("TileFlags", flag_names)
 empty_flags = TileFlags(False, False, False)
 ColorLike = Union[Tuple[int, int, int, int], Tuple[int, int, int], int, str]
 MapPoint = Tuple[int, int, int]
-TiledLayer = Union["TiledTileLayer", "TiledImageLayer", "TiledGroupLayer", "TiledObjectGroup"]
+TiledLayer = Union[
+    "TiledTileLayer", "TiledImageLayer", "TiledGroupLayer", "TiledObjectGroup"
+]
 
 # need a more graceful way to handle annotations for optional dependencies
 if pygame:
@@ -147,7 +149,7 @@ def reshape_data(
         List[List[int]]: 2D nested list object.
 
     """
-    return [gids[i:i + width] for i in range(0, len(gids), width)]
+    return [gids[i : i + width] for i in range(0, len(gids), width)]
 
 
 def unpack_gids(
@@ -618,7 +620,6 @@ class TiledMap(TiledElement):
 
         # iterate through tile objects and handle the image
         for o in [o for o in self.objects if o.gid]:
-
             # gids might also have properties assigned to them
             # in that case, assign the gid properties to the object as well
             p = self.get_tile_properties_by_gid(o.gid)
@@ -644,7 +645,6 @@ class TiledMap(TiledElement):
 
         # iterate through tilesets to get source images
         for ts in self.tilesets:
-
             # skip tilesets without a source
             if ts.source is None:
                 continue
@@ -1224,7 +1224,6 @@ class TiledTileset(TiledElement):
         source = node.get("source", None)
         if source:
             if source[-4:].lower() == ".tsx":
-
                 # external tilesets don't save this, store it for later
                 self.firstgid = int(node.get("firstgid"))
 
@@ -1432,8 +1431,8 @@ class TiledTileLayer(TiledElement):
             )
 
         temp = [
-            self.parent.register_gid_check_flags(gid) for gid in
-            unpack_gids(
+            self.parent.register_gid_check_flags(gid)
+            for gid in unpack_gids(
                 text=data_node.text.strip(),
                 encoding=data_node.get("encoding", None),
                 compression=data_node.get("compression", None),

--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -508,7 +508,7 @@ class TiledMap(TiledElement):
         self.layers = list()  # all layers in proper order
         self.tilesets = list()  # TiledTileset objects
         self.tile_properties = dict()  # tiles that have properties
-        self.layers_by_name = dict()
+        self.layernames = dict()
         self.objects_by_id = dict()
         self.objects_by_name = dict()
 
@@ -931,7 +931,7 @@ class TiledMap(TiledElement):
         )
 
         self.layers.append(layer)
-        self.layers_by_name[layer.name] = layer
+        self.layernames[layer.name] = layer
 
     def add_tileset(self, tileset: TiledTileset) -> None:
         """Add a tileset to the map."""
@@ -952,7 +952,7 @@ class TiledMap(TiledElement):
 
         """
         try:
-            return self.layers_by_name[name]
+            return self.layernames[name]
         except KeyError:
             msg = 'Layer "{0}" not found.'
             logger.debug(msg.format(name))


### PR DESCRIPTION
Implement fix for #174

Attribute dict where layers are stored has been rename for better understanding of its purpose, but I just noticed it was a public attribute not a private one, so sadly this change is probably not acceptable because it's a breaking change.
Waiting for your confirmation on whether I should revert it or not.

`TileLayer` type alias has been introduce to avoid repeating the long union layer type everywhere, but I think having a common base class for all these Layer classes would be even better.

Other changes are reformatting by `black`.