### PR TITLE
Added alphaonly imageloader parameter.

### DIFF
--- a/pytmx/util_pygame.py
+++ b/pytmx/util_pygame.py
@@ -62,6 +62,7 @@ def smart_convert(
     original: pygame.Surface,
     colorkey: Optional[ColorLike],
     pixelalpha: bool,
+    alphaonly: bool
 ) -> pygame.Surface:
     """
     Return new pygame Surface with optimal pixel/data format
@@ -70,12 +71,15 @@ def smart_convert(
     flags and pixel format for each tile surface.
 
     Parameters:
-        original: tile surface to inspect
-        colorkey: optional colorkey for the tileset image
-        pixelalpha: if true, prefer per-pixel alpha surfaces
+        original:   Tile surface to inspect.
+        colorkey:   Optional colorkey for the tileset image.
+        pixelalpha: If true, prefer per-pixel alpha surfaces.  Default is True.
+        alphaonly:  If true, always use per-pixel alpha surfaces.  Default is False.
+                    Use this to correct a common issue where pygame .convert() 
+                    will not display black (0,0,0) pixels from your images.
 
     Returns:
-        new tile surface
+        A new tile surface.
 
     """
     # tiled set a colorkey
@@ -90,22 +94,30 @@ def smart_convert(
         threshold = 254  # the default
 
         try:
-            # count the number of pixels in the tile that are not transparent
+            # Count the number of pixels in the tile that are not transparent.
+            # Pygame .convert() can misbehave.  Calling .mask() correctly determines there are no 
+            # transparent pixels.  But when we call .convert(), it then makes black (0,0,0) pixels 
+            # transparent when we didn't specify alpha behavior.  If this happens to you, consider 
+            # using the alphaonly override.
             px = pygame.mask.from_surface(original, threshold).count()
         except:
             # pygame_sdl2 will fail because the mask module is not included
             # in this case, just convert_alpha and return it
             return original.convert_alpha()
 
-        # there are no transparent pixels in the image
-        if px == tile_size[0] * tile_size[1]:
+        # Caller wants alpha no matter what.  Accommodate them.
+        if alphaonly:
+            tile = original.convert_alpha()
+
+        # There are no transparent pixels in the image.  
+        elif px == tile_size[0] * tile_size[1]:
             tile = original.convert()
 
-        # there are transparent pixels, and set for perpixel alpha
+        # There are transparent pixels, and set for per-pixel alpha.
         elif pixelalpha:
             tile = original.convert_alpha()
 
-        # there are transparent pixels, and we won't handle them
+        # There are transparent pixels, and we won't handle them.
         else:
             tile = original.convert()
 
@@ -117,16 +129,25 @@ def pygame_image_loader(filename: str, colorkey: Optional[ColorLike], **kwargs):
     pytmx image loader for pygame
 
     Parameters:
-        filename: filename, including path, to load
-        colorkey: colorkey for the image
+        filename: The filename, including path, to be loaded.
+        colorkey: The colorkey for the image.
+
+    Optional named parameters:
+        pixelalpha: Intelligently choose to use per-pixel alpha transparency 
+                    only if there are no fully transparent pixels in the 
+                    image and colorkey is not specified.  This is overridden 
+                    if alphaonly is specified.
+        alphaonly : Always use alpha transparency when converting 
+                    images to target surface format.
 
     Returns:
-        function to load tile images
+        A function to load tile images.
 
     """
     if colorkey:
         colorkey = pygame.Color("#{0}".format(colorkey))
 
+    alphaonly = kwargs.get("alphaonly", False)
     pixelalpha = kwargs.get("pixelalpha", True)
     image = pygame.image.load(filename)
 
@@ -143,7 +164,7 @@ def pygame_image_loader(filename: str, colorkey: Optional[ColorLike], **kwargs):
         if flags:
             tile = handle_transformation(tile, flags)
 
-        tile = smart_convert(tile, colorkey, pixelalpha)
+        tile = smart_convert(tile, colorkey, pixelalpha, alphaonly)
         return tile
 
     return load_image


### PR DESCRIPTION
The new alphaonly parameter circumvents the smart part of the smart_convert() method when pygame misbehaves with non-transparent tiles.  This should be a non-breaking change.

Here is the problem I have:  There are certain tiles which I created without transparency will be determined by pygame's .mask() method to have no transparency.  The smart_convert() method then correctly calls .convert() on them.  But then pygame draws these tiles without drawing the black pixels.  As far as I can tell, the problem is in PyGame.  It's possible that it's something weird about my tilesheet imaages, but it only does it with certain tiles.  This is not a bug in pytmx.  I've had this problem for YEARS with pygame.  Whether it's me or them, the solution to my problem is to use convert_alpha().  This new parameter gives me the control to force pytmx to do that.  Without this change, I had to create a custom image loader to solve this problem.  