### PR TITLE
pyproject.toml + isort

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,17 +14,17 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.7.12
-          - 3.8.12
-          - 3.9.7
+          - 3.7
+          - 3.8
+          - 3.9
         dependencies:
           - pygame pyglet
           - pygame
           - pyglet
           - "null"
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Requirements

--- a/apps/benchmark.py
+++ b/apps/benchmark.py
@@ -208,8 +208,9 @@ class SimpleTest(object):
 
 
 if __name__ == "__main__":
-    import os.path
     import glob
+    import os.path
+
     import pytmx
 
     pygame.init()

--- a/apps/pygame_demo.py
+++ b/apps/pygame_demo.py
@@ -21,9 +21,7 @@ import pygame
 from pygame.locals import *
 
 import pytmx
-from pytmx import TiledImageLayer
-from pytmx import TiledObjectGroup
-from pytmx import TiledTileLayer
+from pytmx import TiledImageLayer, TiledObjectGroup, TiledTileLayer
 from pytmx.util_pygame import load_pygame
 
 logger = logging.getLogger(__name__)
@@ -221,8 +219,8 @@ class SimpleTest(object):
 
 
 if __name__ == "__main__":
-    import os.path
     import glob
+    import os.path
 
     pygame.init()
     pygame.font.init()

--- a/apps/pygame_sdl2_demo.py
+++ b/apps/pygame_sdl2_demo.py
@@ -149,8 +149,8 @@ class SimpleTest:
 
 
 if __name__ == "__main__":
-    import os.path
     import glob
+    import os.path
 
     pygame.init()
     pygame.font.init()

--- a/apps/pyglet_demo.py
+++ b/apps/pyglet_demo.py
@@ -17,9 +17,10 @@ ch.setLevel(logging.INFO)
 logger.addHandler(ch)
 logger.setLevel(logging.INFO)
 
+import pyglet
+
 from pytmx import *
 from pytmx.util_pyglet import load_pyglet
-import pyglet
 
 
 class TiledRenderer(object):
@@ -129,8 +130,8 @@ class SimpleTest(object):
 
 
 def all_filenames():
-    import os.path
     import glob
+    import os.path
 
     _list = glob.glob(os.path.join("data", "*.tmx"))
     try:

--- a/apps/pysdl2_demo.py
+++ b/apps/pysdl2_demo.py
@@ -29,10 +29,11 @@ import os
 
 os.environ["PYSDL2_DLL_PATH"] = os.path.dirname(__file__)
 
+import sdl2.ext
+from sdl2 import *
+
 from pytmx import *
 from pytmx.util_pysdl2 import load_pysdl2
-from sdl2 import *
-import sdl2.ext
 
 
 class TiledRenderer(object):
@@ -126,8 +127,8 @@ class SimpleTest(object):
 
 
 def all_filenames():
-    import os.path
     import glob
+    import os.path
 
     return glob.glob(os.path.join("data", "*.tmx"))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "PyTMX"
+version = "3.32"
+description = "Loads tiled tmx maps"
+readme = "readme.md"
+license = {file = "LICENSE"}
+authors = [
+    {name = "bitcraft", email = "leif.theden@gmail.com"}
+]
+classifiers = [
+        "Intended Audience :: Developers",
+        "Development Status :: 5 - Production/Stable",
+        "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Topic :: Games/Entertainment",
+        "Topic :: Multimedia :: Graphics",
+        "Topic :: Software Development :: Libraries :: pygame",
+]
+requires-python = ">=3.7"
+
+[project.urls]
+source = "https://github.com/bitcraft/PyTMX"
+
+[tool.setuptools]
+packages = ["pytmx"]
+
+[project.optional-dependencies]
+pygame = ["pygame>=2.0.0"]
+pygame-ce = ["pygame-ce>=2.1.3"]
+
+[tool.black]
+line-length = 88
+target-version = ["py37"]
+
+[tool.isort]
+line_length = 88
+profile = "black"
+skip_gitignore = true

--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -20,19 +20,19 @@ License along with pytmx.  If not, see <https://www.gnu.org/licenses/>.
 from __future__ import annotations
 
 import gzip
+import json
 import logging
 import os
 import struct
 import zlib
 from base64 import b64decode
 from collections import defaultdict, namedtuple
+from copy import deepcopy
 from itertools import chain, product
 from math import cos, radians, sin
 from operator import attrgetter
-from typing import List, Tuple, Optional, Sequence, Union, Dict, Iterable
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
 from xml.etree import ElementTree
-import json
-from copy import deepcopy
 
 # for type hinting
 try:

--- a/pytmx/util_pygame.py
+++ b/pytmx/util_pygame.py
@@ -19,7 +19,7 @@ License along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
 """
 import itertools
 import logging
-from typing import Optional, Union, List
+from typing import List, Optional, Union
 
 import pytmx
 from pytmx.pytmx import ColorLike, PointLike
@@ -27,8 +27,8 @@ from pytmx.pytmx import ColorLike, PointLike
 logger = logging.getLogger(__name__)
 
 try:
-    from pygame.transform import flip, rotate
     import pygame
+    from pygame.transform import flip, rotate
 except ImportError:
     logger.error("cannot import pygame (is it installed?)")
     raise

--- a/pytmx/util_pygame_sdl2.py
+++ b/pytmx/util_pygame_sdl2.py
@@ -28,8 +28,8 @@ import pytmx
 logger = logging.getLogger(__name__)
 
 try:
-    from pygame._sdl2 import Texture, Image, Renderer, Window
     import pygame
+    from pygame._sdl2 import Image, Renderer, Texture, Window
 except ImportError:
     logger.error("cannot import pygame (is it installed?)")
     raise

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description_file = readme.md

--- a/setup.py
+++ b/setup.py
@@ -5,31 +5,4 @@
 # python3 -m twine upload --repository pypi dist/*
 from setuptools import setup
 
-setup(
-    name="PyTMX",
-    version="3.32",
-    description="Loads tiled tmx maps",
-    author="bitcraft",
-    author_email="leif.theden@gmail.com",
-    packages=["pytmx"],
-    license="LGPLv3",
-    long_description="https://github.com/bitcraft/PyTMX",
-    python_requires=">=3.7",
-    extras_require={
-        "pygame": ["pygame>=2.0.0"],
-        "pygame-ce": ["pygame-ce>=2.1.3"],
-    },
-    classifiers=[
-        "Intended Audience :: Developers",
-        "Development Status :: 5 - Production/Stable",
-        "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Topic :: Games/Entertainment",
-        "Topic :: Multimedia :: Graphics",
-        "Topic :: Software Development :: Libraries :: pygame",
-    ],
-)
+setup()

--- a/tests/pytmx/test_pytmx.py
+++ b/tests/pytmx/test_pytmx.py
@@ -1,8 +1,7 @@
 import unittest
 
 import pytmx
-from pytmx import TiledElement
-from pytmx import convert_to_bool
+from pytmx import TiledElement, convert_to_bool
 
 
 class TestConvertToBool(unittest.TestCase):


### PR DESCRIPTION
PR:
- gets rid of setup() and implements **pyproject.toml**;
- updates workflows actions **checkout** and **setup-python** (last version);
- isort everything;

I don't know if `requires = ["setuptools", "setuptools-scm"]` requires the "wheel".
