### PR TITLE
py39 + typing (List > list, etc.) + some typehints

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,7 @@ jobs:
     runs-on: [ubuntu-latest]
     strategy:
       matrix:
-        python-version:
-          - 3.7
-          - 3.8
-          - 3.9
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         dependencies:
           - pygame pyglet
           - pygame

--- a/apps/benchmark.py
+++ b/apps/benchmark.py
@@ -1,6 +1,6 @@
 """
 This is tested on pygame 1.9 and python 2.7 and 3.3+.
-Leif Theden "bitcraft", 2012-2022
+Leif Theden "bitcraft", 2012-2024
 
 Rendering demo for the TMXLoader.
 
@@ -41,7 +41,7 @@ class TiledRenderer(object):
     Super simple way to render a tiled map
     """
 
-    def __init__(self, filename):
+    def __init__(self, filename) -> None:
         tm = load_pygame(filename)
 
         # self.size will be the pixel size of the map
@@ -55,7 +55,7 @@ class TiledRenderer(object):
                 print(i)
                 continue
 
-    def render_map(self, surface):
+    def render_map(self, surface) -> None:
         """Render our map to a pygame surface
 
         Feel free to use this as a starting point for your pygame app.
@@ -84,7 +84,7 @@ class TiledRenderer(object):
             elif isinstance(layer, TiledImageLayer):
                 self.render_image_layer(surface, layer)
 
-    def render_tile_layer(self, surface, layer):
+    def render_tile_layer(self, surface, layer) -> None:
         """Render all TiledTiles in this layer"""
         # deref these heavily used references for speed
         tw = self.tmx_data.tilewidth
@@ -95,7 +95,7 @@ class TiledRenderer(object):
         for x, y, image in layer.tiles():
             surface_blit(image, (x * tw, y * th))
 
-    def render_object_layer(self, surface, layer):
+    def render_object_layer(self, surface, layer) -> None:
         """Render all TiledObjects contained in this layer"""
         # deref these heavily used references for speed
         draw_rect = pygame.draw.rect
@@ -125,7 +125,7 @@ class TiledRenderer(object):
             else:
                 draw_rect(surface, rect_color, (obj.x, obj.y, obj.width, obj.height), 3)
 
-    def render_image_layer(self, surface, layer):
+    def render_image_layer(self, surface, layer) -> None:
         if layer.image:
             surface.blit(layer.image, (0, 0))
 
@@ -133,18 +133,18 @@ class TiledRenderer(object):
 class SimpleTest(object):
     """Basic app to display a rendered Tiled map"""
 
-    def __init__(self, filename):
+    def __init__(self, filename) -> None:
         self.renderer = None
         self.running = False
         self.dirty = False
         self.exit_status = 0
         self.load_map(filename)
 
-    def load_map(self, filename):
+    def load_map(self, filename) -> None:
         """Create a renderer, load data, and print some debug info"""
         self.renderer = TiledRenderer(filename)
 
-    def draw(self, surface):
+    def draw(self, surface) -> None:
         """Draw our map to some surface (probably the display)"""
         # first we make a temporary surface that will accommodate the entire
         # size of the map.
@@ -164,7 +164,7 @@ class SimpleTest(object):
         i = f.render("press any key for next map or ESC to quit", 1, (180, 180, 0))
         surface.blit(i, (0, 0))
 
-    def handle_input(self):
+    def handle_input(self) -> None:
         try:
             event = pygame.event.wait()
 

--- a/apps/pygame_demo.py
+++ b/apps/pygame_demo.py
@@ -1,6 +1,6 @@
 """
 This is tested on pygame 1.9 and python 2.7 and 3.3+.
-Leif Theden "bitcraft", 2012-2023
+Leif Theden "bitcraft", 2012-2024
 
 Rendering demo for the TMXLoader.
 
@@ -39,7 +39,7 @@ class TiledRenderer(object):
     Super simple way to render a tiled map
     """
 
-    def __init__(self, filename):
+    def __init__(self, filename) -> None:
         tm = load_pygame(filename)
 
         # self.size will be the pixel size of the map
@@ -47,7 +47,7 @@ class TiledRenderer(object):
         self.pixel_size = tm.width * tm.tilewidth, tm.height * tm.tileheight
         self.tmx_data = tm
 
-    def render_map(self, surface):
+    def render_map(self, surface) -> None:
         """Render our map to a pygame surface
 
         Feel free to use this as a starting point for your pygame app.
@@ -76,7 +76,7 @@ class TiledRenderer(object):
             elif isinstance(layer, TiledImageLayer):
                 self.render_image_layer(surface, layer)
 
-    def render_tile_layer(self, surface, layer):
+    def render_tile_layer(self, surface, layer) -> None:
         """Render all TiledTiles in this layer"""
         # deref these heavily used references for speed
         tw = self.tmx_data.tilewidth
@@ -96,7 +96,7 @@ class TiledRenderer(object):
                 sy = x * th2 + y * th2
                 surface_blit(image, (sx + ox, sy))
 
-    def render_object_layer(self, surface, layer):
+    def render_object_layer(self, surface, layer) -> None:
         """Render all TiledObjects contained in this layer"""
         # deref these heavily used references for speed
         draw_lines = pygame.draw.lines
@@ -122,7 +122,7 @@ class TiledRenderer(object):
                     surface, rect_color, obj.closed, obj.apply_transformations(), 3
                 )
 
-    def render_image_layer(self, surface, layer):
+    def render_image_layer(self, surface, layer) -> None:
         if layer.image:
             surface.blit(layer.image, (0, 0))
 
@@ -130,14 +130,14 @@ class TiledRenderer(object):
 class SimpleTest(object):
     """Basic app to display a rendered Tiled map"""
 
-    def __init__(self, filename):
+    def __init__(self, filename) -> None:
         self.renderer = None
         self.running = False
         self.dirty = False
         self.exit_status = 0
         self.load_map(filename)
 
-    def load_map(self, filename):
+    def load_map(self, filename) -> None:
         """Create a renderer, load data, and print some debug info"""
         self.renderer = TiledRenderer(filename)
 
@@ -155,7 +155,7 @@ class SimpleTest(object):
         for k, v in self.renderer.tmx_data.get_tile_colliders():
             logger.info("%s\t%s", k, list(v))
 
-    def draw(self, surface):
+    def draw(self, surface) -> None:
         """Draw our map to some surface (probably the display)"""
         # first we make a temporary surface that will accommodate the entire
         # size of the map.
@@ -175,7 +175,7 @@ class SimpleTest(object):
         i = f.render("press any key for next map or ESC to quit", 1, (180, 180, 0))
         surface.blit(i, (0, 0))
 
-    def handle_input(self):
+    def handle_input(self) -> None:
         try:
             event = pygame.event.wait()
 

--- a/apps/pygame_sdl2_demo.py
+++ b/apps/pygame_sdl2_demo.py
@@ -1,6 +1,6 @@
 """
 This is tested on pygame 2.0.1 and python 3.9.6.
-Leif Theden "bitcraft", 2012-2022
+Leif Theden "bitcraft", 2012-2024
 
 Rendering demo for the TMXLoader.
 
@@ -32,12 +32,12 @@ class TiledRenderer(object):
 
     """
 
-    def __init__(self, ctx: GameContext, filename):
+    def __init__(self, ctx: GameContext, filename) -> None:
         self.ctx = ctx
         self.tmx_data = tm = load_pygame_sdl2(ctx.renderer, filename)
         self.pixel_size = tm.width * tm.tilewidth, tm.height * tm.tileheight
 
-    def render_map(self):
+    def render_map(self) -> None:
         """
         Render our map to a pygame surface
 
@@ -53,7 +53,7 @@ class TiledRenderer(object):
             if isinstance(layer, TiledTileLayer):
                 self.render_tile_layer(layer)
 
-    def render_tile_layer(self, layer):
+    def render_tile_layer(self, layer) -> None:
         """
         Render all TiledTiles in this layer
 
@@ -81,14 +81,14 @@ class SimpleTest:
 
     """
 
-    def __init__(self, ctx: GameContext, filename):
+    def __init__(self, ctx: GameContext, filename) -> None:
         self.ctx = ctx
         self.map_renderer = None
         self.running = False
         self.exit_status = 0
         self.load_map(filename)
 
-    def load_map(self, filename):
+    def load_map(self, filename) -> None:
         """
         Create a renderer, load data, and print some debug info
 
@@ -109,7 +109,7 @@ class SimpleTest:
         for k, v in self.map_renderer.tmx_data.get_tile_colliders():
             logger.info("%s\t%s", k, list(v))
 
-    def draw(self):
+    def draw(self) -> None:
         """
         Draw our map to some surface (probably the display)
 
@@ -117,7 +117,7 @@ class SimpleTest:
         self.map_renderer.render_map()
         self.ctx.renderer.present()
 
-    def handle_input(self):
+    def handle_input(self) -> None:
         try:
             event = pygame.event.wait()
 

--- a/apps/pyglet_demo.py
+++ b/apps/pyglet_demo.py
@@ -1,6 +1,6 @@
 """
 This is tested on pyglet 1.2 and python 2.7.
-Leif Theden "bitcraft", 2012-2022
+Leif Theden "bitcraft", 2012-2024
 
 Rendering demo for the TMXLoader.
 
@@ -30,7 +30,7 @@ class TiledRenderer(object):
     no shape drawing yet
     """
 
-    def __init__(self, filename):
+    def __init__(self, filename) -> None:
         tm = load_pyglet(filename)
         self.size = tm.width * tm.tilewidth, tm.height * tm.tileheight
         self.tmx_data = tm
@@ -39,13 +39,13 @@ class TiledRenderer(object):
         self.generate_sprites()
         self.clock_display = pyglet.clock.ClockDisplay()
 
-    def draw_rect(self, color, rect, width):
+    def draw_rect(self, color, rect, width) -> None:
         pass
 
-    def draw_lines(self, color, closed, points, width):
+    def draw_lines(self, color, closed, points, width) -> None:
         pass
 
-    def generate_sprites(self):
+    def generate_sprites(self) -> None:
         tw = self.tmx_data.tilewidth
         th = self.tmx_data.tileheight
         mw = self.tmx_data.width
@@ -98,21 +98,21 @@ class TiledRenderer(object):
                     sprite = pyglet.sprite.Sprite(layer.image, batch=batch, x=x, y=y)
                     self.sprites.append(sprite)
 
-    def draw(self):
+    def draw(self) -> None:
         for b in self.batches:
             b.draw()
         self.clock_display.draw()
 
 
 class SimpleTest(object):
-    def __init__(self, filename):
+    def __init__(self, filename) -> None:
         self.renderer = None
         self.running = False
         self.dirty = False
         self.exit_status = 0
         self.load_map(filename)
 
-    def load_map(self, filename):
+    def load_map(self, filename) -> None:
         self.renderer = TiledRenderer(filename)
 
         logger.info("Objects in map:")
@@ -125,7 +125,7 @@ class SimpleTest(object):
         for k, v in self.renderer.tmx_data.tile_properties.items():
             logger.info("%s\t%s", k, v)
 
-    def draw(self):
+    def draw(self) -> None:
         self.renderer.draw()
 
 
@@ -142,7 +142,7 @@ def all_filenames():
 
 
 class TestWindow(pyglet.window.Window):
-    def on_draw(self):
+    def on_draw(self) -> None:
         if not hasattr(self, "filenames"):
             self.filenames = all_filenames()
             self.next_map()
@@ -150,7 +150,7 @@ class TestWindow(pyglet.window.Window):
         self.clear()
         self.contents.draw()
 
-    def next_map(self):
+    def next_map(self) -> None:
         try:
             self.contents = SimpleTest(next(self.filenames))
         except StopIteration:

--- a/apps/pysdl2_demo.py
+++ b/apps/pysdl2_demo.py
@@ -1,6 +1,6 @@
 """
 This is tested on pysdl2 1.2 and python 2.7.
-Leif Theden "bitcraft", 2012-2022
+Leif Theden "bitcraft", 2012-2024
 
 Rendering demo for the TMXLoader.
 
@@ -43,13 +43,13 @@ class TiledRenderer(object):
     no shape drawing yet
     """
 
-    def __init__(self, filename, renderer):
+    def __init__(self, filename, renderer) -> None:
         tm = load_pysdl2(renderer, filename)
         self.size = tm.width * tm.tilewidth, tm.height * tm.tileheight
         self.tmx_data = tm
         self.renderer = renderer
 
-    def render_tile_layer(self, layer):
+    def render_tile_layer(self, layer) -> None:
         """Render the tile layer
 
         DOES NOT CHECK FOR DRAWING TILES OFF THE SCREEN
@@ -69,7 +69,7 @@ class TiledRenderer(object):
             angle = 90 if (flip & 4) else 0
             rce(renderer, texture, src, dest, angle, None, flip)
 
-    def render_map(self):
+    def render_map(self) -> None:
         """Render the entire map
 
         Only tile layer drawing is implemented
@@ -82,7 +82,7 @@ class TiledRenderer(object):
 
 
 class SimpleTest(object):
-    def __init__(self, filename, window):
+    def __init__(self, filename, window) -> None:
         self.running = False
         self.dirty = False
         self.exit_status = 0
@@ -99,7 +99,7 @@ class SimpleTest(object):
         for k, v in self.map_renderer.tmx_data.tile_properties.items():
             logger.info("%s\t%s", k, v)
 
-    def draw(self):
+    def draw(self) -> None:
         self.sdl_renderer.clear()
         self.map_renderer.render_map()
         self.sdl_renderer.present()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,10 +18,10 @@ sys.path.insert(0, os.path.abspath("../"))
 
 
 # -- Project information -----------------------------------------------------
-from typing import Any, List
+from typing import Any
 
 project = "pytmx"
-copyright = "2012-2021, Leif Theden"
+copyright = "2012-2024, Leif Theden"
 author = "Leif Theden"
 
 # The full version, including alpha/beta/rc tags
@@ -72,7 +72,7 @@ napoleon_custom_sections = ["Script usage", ("Script parameters", "params_style"
 # Apidoc call to generate automatic reference docs. Taken from
 # https://github.com/readthedocs/readthedocs.org/issues/1139#issuecomment-398083449
 def run_apidoc(_: Any) -> None:
-    ignore_paths: List[str] = []
+    ignore_paths: list[str] = []
 
     argv = ["-f", "-e", "-M", "-o", "autogen", ".."] + ignore_paths
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,6 @@ classifiers = [
         "Intended Audience :: Developers",
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -25,7 +23,7 @@ classifiers = [
         "Topic :: Multimedia :: Graphics",
         "Topic :: Software Development :: Libraries :: pygame",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 
 [project.urls]
 source = "https://github.com/bitcraft/PyTMX"
@@ -39,7 +37,7 @@ pygame-ce = ["pygame-ce>=2.1.3"]
 
 [tool.black]
 line-length = 88
-target-version = ["py37"]
+target-version = ["py39"]
 
 [tool.isort]
 line_length = 88

--- a/pytmx/__init__.py
+++ b/pytmx/__init__.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2012-2023, Leif Theden <leif.theden@gmail.com>
+Copyright (C) 2012-2024, Leif Theden <leif.theden@gmail.com>
 
 This file is part of pytmx.
 
@@ -28,6 +28,3 @@ except ImportError:
     logger.debug("cannot import pygame tools")
 
 __version__ = (3, 32)
-__author__ = "bitcraft"
-__author_email__ = "leif.theden@gmail.com"
-__description__ = "Map loader for TMX Files - Python 3.3 +"

--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2012-2023, Leif Theden <leif.theden@gmail.com>
+Copyright (C) 2012-2024, Leif Theden <leif.theden@gmail.com>
 
 This file is part of pytmx.
 
@@ -27,11 +27,12 @@ import struct
 import zlib
 from base64 import b64decode
 from collections import defaultdict, namedtuple
+from collections.abc import Iterable, Sequence
 from copy import deepcopy
 from itertools import chain, product
 from math import cos, radians, sin
 from operator import attrgetter
-from typing import Dict, Iterable, List, Optional, Sequence, Tuple, Union
+from typing import Optional, Union
 from xml.etree import ElementTree
 
 # for type hinting
@@ -79,17 +80,17 @@ AnimationFrame = namedtuple("AnimationFrame", ["gid", "duration"])
 Point = namedtuple("Point", ["x", "y"])
 TileFlags = namedtuple("TileFlags", flag_names)
 empty_flags = TileFlags(False, False, False)
-ColorLike = Union[Tuple[int, int, int, int], Tuple[int, int, int], int, str]
-MapPoint = Tuple[int, int, int]
+ColorLike = Union[tuple[int, int, int, int], tuple[int, int, int], int, str]
+MapPoint = tuple[int, int, int]
 TiledLayer = Union[
     "TiledTileLayer", "TiledImageLayer", "TiledGroupLayer", "TiledObjectGroup"
 ]
 
 # need a more graceful way to handle annotations for optional dependencies
 if pygame:
-    PointLike = Union[Tuple[int, int], pygame.Vector2, Point]
+    PointLike = Union[tuple[int, int], pygame.Vector2, Point]
 else:
-    PointLike = Union[Tuple[int, int], Point]
+    PointLike = Union[tuple[int, int], Point]
 
 
 def default_image_loader(filename: str, flags, **kwargs):
@@ -112,7 +113,7 @@ def default_image_loader(filename: str, flags, **kwargs):
     return load
 
 
-def decode_gid(raw_gid: int) -> Tuple[int, TileFlags]:
+def decode_gid(raw_gid: int) -> tuple[int, TileFlags]:
     """Decode a GID from TMX data.
 
     Args:
@@ -136,9 +137,9 @@ def decode_gid(raw_gid: int) -> Tuple[int, TileFlags]:
 
 
 def reshape_data(
-    gids: List[int],
+    gids: list[int],
     width: int,
-) -> List[List[int]]:
+) -> list[list[int]]:
     """Change 1D list to 2d list
 
     Args:
@@ -156,7 +157,7 @@ def unpack_gids(
     text: str,
     encoding: Optional[str] = None,
     compression: Optional[str] = None,
-) -> List[int]:
+) -> list[int]:
     """Return all gids from encoded/compressed layer data
 
     Args:
@@ -184,7 +185,7 @@ def unpack_gids(
         raise ValueError(f"layer encoding {encoding} is not supported.")
 
 
-def convert_to_bool(value: str) -> bool:
+def convert_to_bool(value: Optional[Union[str, int, float]] = None) -> bool:
     """Convert a few common variations of "true" and "false" to boolean
 
     Args:
@@ -230,7 +231,7 @@ def rotate(
     points: Sequence[Point],
     origin: Point,
     angle: Union[int, float],
-) -> List[Point]:
+) -> list[Point]:
     """Rotate a sequence of points around an axis.
 
     Args:
@@ -330,7 +331,7 @@ prop_type = {
 }
 
 
-def parse_properties(node: ElementTree.Element, customs: dict = None) -> Dict:
+def parse_properties(node: ElementTree.Element, customs: dict = None) -> dict:
     """Parse a Tiled xml node and return a dict.
 
     Args:
@@ -372,7 +373,7 @@ class TiledElement:
 
     allow_duplicate_names = False
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.properties = dict()
 
     @classmethod
@@ -458,7 +459,7 @@ class TiledElement:
 class TiledClassType:
     """Contains custom Tiled types."""
 
-    def __init__(self, name: str, members: List[dict]) -> None:
+    def __init__(self, name: str, members: list[dict]) -> None:
         """Creates the TiledClassType.
 
         Args:
@@ -477,7 +478,7 @@ class TiledMap(TiledElement):
     def __init__(
         self,
         filename: Optional[str] = None,
-        custom_property_filename: Optional[List[str]] = None,
+        custom_property_filename: Optional[list[str]] = None,
         image_loader=default_image_loader,
         **kwargs,
     ) -> None:
@@ -809,7 +810,7 @@ class TiledMap(TiledElement):
             logger.debug(msg.format(x, y, layer))
             raise ValueError(msg.format(x, y, layer))
 
-    def get_tile_properties(self, x: int, y: int, layer: int) -> Optional[Dict]:
+    def get_tile_properties(self, x: int, y: int, layer: int) -> Optional[dict]:
         """Return the tile image GID for this location.
 
         Args:
@@ -864,7 +865,7 @@ class TiledMap(TiledElement):
             for x, y, _gid in [i for i in self.layers[l].iter_data() if i[2] == gid]:
                 yield x, y, l
 
-    def get_tile_properties_by_gid(self, gid: int) -> Optional[Dict]:
+    def get_tile_properties_by_gid(self, gid: int) -> Optional[dict]:
         """Get the tile properties of a tile GID.
 
         Args:
@@ -1009,7 +1010,7 @@ class TiledMap(TiledElement):
 
         raise ValueError("Tileset not found")
 
-    def get_tile_colliders(self) -> Iterable[Tuple[int, List[Dict]]]:
+    def get_tile_colliders(self) -> Iterable[tuple[int, list[dict]]]:
         """Return iterator of (gid, dict) pairs of tiles with colliders.
 
         Returns:
@@ -1021,7 +1022,7 @@ class TiledMap(TiledElement):
             if colliders:
                 yield gid, colliders
 
-    def pixels_to_tile_pos(self, position: Tuple[int, int]) -> Tuple[int, int]:
+    def pixels_to_tile_pos(self, position: tuple[int, int]) -> tuple[int, int]:
         return int(position[0] / self.tilewidth), int(position[1] / self.tileheight)
 
     @property
@@ -1138,7 +1139,7 @@ class TiledMap(TiledElement):
         else:
             return self.register_gid(*decode_gid(tiled_gid))
 
-    def map_gid(self, tiled_gid: int) -> Optional[List[int]]:
+    def map_gid(self, tiled_gid: int) -> Optional[list[int]]:
         """Used to lookup a GID read from a TMX file's data.
 
         Args:
@@ -1157,7 +1158,7 @@ class TiledMap(TiledElement):
             logger.debug(msg)
             raise TypeError(msg)
 
-    def map_gid2(self, tiled_gid: int) -> List[Tuple[int, Optional[int]]]:
+    def map_gid2(self, tiled_gid: int) -> list[tuple[int, Optional[int]]]:
         """WIP.  need to refactor the gid code"""
         tiled_gid = int(tiled_gid)
 
@@ -1375,7 +1376,7 @@ class TiledTileLayer(TiledElement):
     def __iter__(self):
         return self.iter_data()
 
-    def iter_data(self) -> Iterable[Tuple[int, int, int]]:
+    def iter_data(self) -> Iterable[tuple[int, int, int]]:
         """Yields X, Y, GID tuples for each tile in the layer.
 
         Returns:
@@ -1574,7 +1575,7 @@ class TiledObject(TiledElement):
 
         return self
 
-    def apply_transformations(self) -> List[Point]:
+    def apply_transformations(self) -> list[Point]:
         """Return all points for object, taking in account rotation."""
         if hasattr(self, "points"):
             return rotate(self.points, self, self.rotation)
@@ -1582,9 +1583,7 @@ class TiledObject(TiledElement):
             return rotate(self.as_points, self, self.rotation)
 
     @property
-    def as_points(
-        self,
-    ) -> List[Point]:
+    def as_points(self) -> list[Point]:
         return [
             Point(*i)
             for i in [

--- a/pytmx/util_pygame.py
+++ b/pytmx/util_pygame.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Copyright (C) 2012-2023, Leif Theden <leif.theden@gmail.com>
+Copyright (C) 2012-2024, Leif Theden <leif.theden@gmail.com>
 
 This file is part of pytmx.
 
@@ -19,7 +19,7 @@ License along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
 """
 import itertools
 import logging
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 import pytmx
 from pytmx.pytmx import ColorLike, PointLike
@@ -188,7 +188,7 @@ def build_rects(
     layer: Union[int, str],
     tileset: Optional[Union[int, str]],
     real_gid: Optional[int],
-) -> List[pygame.Rect]:
+) -> list[pygame.Rect]:
     """
     Generate a set of non-overlapping rects that represents the distribution of the specified gid.
 
@@ -258,10 +258,10 @@ def build_rects(
 
 
 def simplify(
-    all_points: List[PointLike],
+    all_points: list[PointLike],
     tilewidth: int,
     tileheight: int,
-) -> List[pygame.Rect]:
+) -> list[pygame.Rect]:
     """Given a list of points, return list of rects that represent them
     kludge:
 
@@ -304,7 +304,7 @@ def simplify(
     making a list of rects, one for each tile on the map!
     """
 
-    def pick_rect(points, rects):
+    def pick_rect(points, rects) -> None:
         ox, oy = sorted([(sum(p), p) for p in points])[0][1]
         x = ox
         y = oy

--- a/pytmx/util_pygame_sdl2.py
+++ b/pytmx/util_pygame_sdl2.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2012-2022, Leif Theden <leif.theden@gmail.com>
+Copyright (C) 2012-2024, Leif Theden <leif.theden@gmail.com>
 
 This file is part of pytmx.
 
@@ -19,7 +19,7 @@ License along with pytmx.  If not, see <http://www.gnu.org/licenses/>.
 import dataclasses
 import logging
 from functools import partial
-from typing import Tuple
+from typing import Any, Optional
 
 from pygame.rect import Rect
 
@@ -39,14 +39,14 @@ except ImportError:
 class PygameSDL2Tile:
     texture: Texture
     srcrect: Rect
-    size: Tuple[int, int]
+    size: tuple[int, int]
     angle: float = 0.0
     center: None = None
     flipx: bool = False
     flipy: bool = False
 
 
-def handle_flags(flags: pytmx.TileFlags):
+def handle_flags(flags: Optional[pytmx.TileFlags]) -> tuple[float, bool, bool]:
     """
     Return angle and flip values for the SDL2 renderer
 
@@ -94,7 +94,9 @@ def pygame_sd2_image_loader(renderer: Renderer, filename: str, colorkey, **kwarg
     return load_image
 
 
-def load_pygame_sdl2(renderer: Renderer, filename: str, *args, **kwargs):
+def load_pygame_sdl2(
+    renderer: Renderer, filename: str, *args: Any, **kwargs: Any
+) -> pytmx.TiledMap:
     """
     Load a TMX file, images, and return a TiledMap class
 

--- a/pytmx/util_pyglet.py
+++ b/pytmx/util_pyglet.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Copyright (C) 2012-2017, Leif Theden <leif.theden@gmail.com>
+Copyright (C) 2012-2024, Leif Theden <leif.theden@gmail.com>
 
 This file is part of pytmx.
 

--- a/pytmx/util_pysdl2.py
+++ b/pytmx/util_pysdl2.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """
-Copyright (C) 2012-2017, Leif Theden <leif.theden@gmail.com>
+Copyright (C) 2012-2024, Leif Theden <leif.theden@gmail.com>
 
 This file is part of pytmx.
 

--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,7 @@ A map loader for Python/pygame, designed for video games
 
 About
 ===============================================================================
-**For Python 3.7+**
+**For Python 3.9+**
 A map loader for python/pygame designed for games. It provides smart
 tile loading with a fast and efficient storage base. Not only does it
 correctly handle most Tiled object types, it also will load metadata for

--- a/tests/pytmx/test_pytmx.py
+++ b/tests/pytmx/test_pytmx.py
@@ -5,7 +5,7 @@ from pytmx import TiledElement, convert_to_bool
 
 
 class TestConvertToBool(unittest.TestCase):
-    def test_string_string_true(self):
+    def test_string_string_true(self) -> None:
         self.assertTrue(convert_to_bool("1"))
         self.assertTrue(convert_to_bool("y"))
         self.assertTrue(convert_to_bool("Y"))
@@ -18,7 +18,7 @@ class TestConvertToBool(unittest.TestCase):
         self.assertTrue(convert_to_bool("True"))
         self.assertTrue(convert_to_bool("TRUE"))
 
-    def test_string_string_false(self):
+    def test_string_string_false(self) -> None:
         self.assertFalse(convert_to_bool("0"))
         self.assertFalse(convert_to_bool("n"))
         self.assertFalse(convert_to_bool("N"))
@@ -31,36 +31,36 @@ class TestConvertToBool(unittest.TestCase):
         self.assertFalse(convert_to_bool("False"))
         self.assertFalse(convert_to_bool("FALSE"))
 
-    def test_string_number_true(self):
+    def test_string_number_true(self) -> None:
         self.assertTrue(convert_to_bool(1))
         self.assertTrue(convert_to_bool(1.0))
 
-    def test_string_number_false(self):
+    def test_string_number_false(self) -> None:
         self.assertFalse(convert_to_bool(0))
         self.assertFalse(convert_to_bool(0.0))
         self.assertFalse(convert_to_bool(-1))
         self.assertFalse(convert_to_bool(-1.1))
 
-    def test_string_bool_true(self):
+    def test_string_bool_true(self) -> None:
         self.assertTrue(convert_to_bool(True))
 
-    def test_string_bool_false(self):
+    def test_string_bool_false(self) -> None:
         self.assertFalse(convert_to_bool(False))
 
-    def test_string_bool_none(self):
+    def test_string_bool_none(self) -> None:
         self.assertFalse(convert_to_bool(None))
 
-    def test_string_bool_empty(self):
+    def test_string_bool_empty(self) -> None:
         self.assertFalse(convert_to_bool(""))
 
-    def test_string_bool_whitespace_only(self):
+    def test_string_bool_whitespace_only(self) -> None:
         self.assertFalse(convert_to_bool(" "))
 
-    def test_non_boolean_string_raises_error(self):
+    def test_non_boolean_string_raises_error(self) -> None:
         with self.assertRaises(ValueError):
             convert_to_bool("garbage")
 
-    def test_non_boolean_number_raises_error(self):
+    def test_non_boolean_number_raises_error(self) -> None:
         with self.assertRaises(ValueError):
             convert_to_bool("200")
 
@@ -68,10 +68,10 @@ class TestConvertToBool(unittest.TestCase):
 class TiledMapTest(unittest.TestCase):
     filename = "tests/resources/test01.tmx"
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.m = pytmx.TiledMap(self.filename)
 
-    def test_build_rects(self):
+    def test_build_rects(self) -> None:
         try:
             from pytmx import util_pygame
 
@@ -82,30 +82,30 @@ class TiledMapTest(unittest.TestCase):
         except ImportError:
             pass
 
-    def test_get_tile_image(self):
+    def test_get_tile_image(self) -> None:
         image = self.m.get_tile_image(0, 0, 0)
 
-    def test_get_tile_image_by_gid(self):
+    def test_get_tile_image_by_gid(self) -> None:
         image = self.m.get_tile_image_by_gid(0)
         self.assertIsNone(image)
 
         image = self.m.get_tile_image_by_gid(1)
         self.assertIsNotNone(image)
 
-    def test_reserved_names_check_disabled_with_option(self):
+    def test_reserved_names_check_disabled_with_option(self) -> None:
         pytmx.TiledElement.allow_duplicate_names = False
         pytmx.TiledMap(allow_duplicate_names=True)
         self.assertTrue(pytmx.TiledElement.allow_duplicate_names)
 
-    def test_map_width_height_is_int(self):
+    def test_map_width_height_is_int(self) -> None:
         self.assertIsInstance(self.m.width, int)
         self.assertIsInstance(self.m.height, int)
 
-    def test_layer_width_height_is_int(self):
+    def test_layer_width_height_is_int(self) -> None:
         self.assertIsInstance(self.m.layers[0].width, int)
         self.assertIsInstance(self.m.layers[0].height, int)
 
-    def test_properties_are_converted_to_builtin_types(self):
+    def test_properties_are_converted_to_builtin_types(self) -> None:
         self.assertIsInstance(self.m.properties["test_bool"], bool)
         self.assertIsInstance(self.m.properties["test_color"], str)
         self.assertIsInstance(self.m.properties["test_file"], str)
@@ -113,11 +113,11 @@ class TiledMapTest(unittest.TestCase):
         self.assertIsInstance(self.m.properties["test_int"], int)
         self.assertIsInstance(self.m.properties["test_string"], str)
 
-    def test_properties_are_converted_to_correct_values(self):
+    def test_properties_are_converted_to_correct_values(self) -> None:
         self.assertFalse(self.m.properties["test_bool"])
         self.assertTrue(self.m.properties["test_bool_true"])
 
-    def test_pixels_to_tile_pos(self):
+    def test_pixels_to_tile_pos(self) -> None:
         self.assertEqual(self.m.pixels_to_tile_pos((0, 33)), (0, 2))
         self.assertEqual(self.m.pixels_to_tile_pos((33, 0)), (2, 0))
         self.assertEqual(self.m.pixels_to_tile_pos((0, 0)), (0, 0))
@@ -125,14 +125,14 @@ class TiledMapTest(unittest.TestCase):
 
 
 class TiledElementTestCase(unittest.TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.element = TiledElement()
 
-    def test_from_xml_string_should_raise_on_TiledElement(self):
+    def test_from_xml_string_should_raise_on_TiledElement(self) -> None:
         with self.assertRaises(AttributeError):
             TiledElement.from_xml_string("<element></element>")
 
-    def test_contains_reserved_property_name(self):
+    def test_contains_reserved_property_name(self) -> None:
         """Reserved names are checked from any attributes in the instance
         after it is created.  Instance attributes are defaults from the
         specification.  We check that new properties are not named same
@@ -143,7 +143,7 @@ class TiledElementTestCase(unittest.TestCase):
         result = self.element._contains_invalid_property_name(items.items())
         self.assertTrue(result)
 
-    def test_not_contains_reserved_property_name(self):
+    def test_not_contains_reserved_property_name(self) -> None:
         """Reserved names are checked from any attributes in the instance
         after it is created.  Instance attributes are defaults from the
         specification.  We check that new properties are not named same
@@ -153,7 +153,7 @@ class TiledElementTestCase(unittest.TestCase):
         result = self.element._contains_invalid_property_name(items.items())
         self.assertFalse(result)
 
-    def test_reserved_names_check_disabled_with_option(self):
+    def test_reserved_names_check_disabled_with_option(self) -> None:
         """Reserved names are checked from any attributes in the instance
         after it is created.  Instance attributes are defaults from the
         specification.  We check that new properties are not named same
@@ -167,6 +167,6 @@ class TiledElementTestCase(unittest.TestCase):
         result = self.element._contains_invalid_property_name(items.items())
         self.assertFalse(result)
 
-    def test_repr(self):
+    def test_repr(self) -> None:
         self.element.name = "foo"
         self.assertEqual('<TiledElement: "foo">', self.element.__repr__())


### PR DESCRIPTION
PR:
- bumps to python 3.9;
- updates copyright dates;
- replaces List with list, Dict with dict, etc.
- moves Sequence, etc into collections.abc;
- gets rid of some typehints (mostly missing **-> None** at the end of the def) : 376 > 289 (I noticed others, but I didn't want to push too far)
