### PR TITLE
Added optional support for zstd compression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ packages = ["pytmx"]
 [project.optional-dependencies]
 pygame = ["pygame>=2.0.0"]
 pygame-ce = ["pygame-ce>=2.1.3"]
+zstd = ["zstd>=1.5.5.1"]
 
 [tool.black]
 line-length = 88

--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import struct
+import sys
 import zlib
 from base64 import b64decode
 from collections import defaultdict, namedtuple
@@ -40,6 +41,12 @@ try:
     import pygame
 except ImportError:
     pygame = None
+
+# optional zstd compression support
+try:
+    import zstd
+except ImportError:
+    zstd = False
 
 __all__ = (
     "TileFlags",
@@ -175,6 +182,14 @@ def unpack_gids(
             data = gzip.decompress(data)
         elif compression == "zlib":
             data = zlib.decompress(data)
+        elif compression == "zstd":
+            if zstd:
+                data = zstd.decompress(data)
+            else:
+                raise ValueError(
+                    "layer compression zstd is not supported. Install zstd "
+                    "to enable support."
+                )
         elif compression:
             raise ValueError(f"layer compression {compression} is not supported.")
         fmt = "<%dL" % (len(data) // 4)

--- a/readme.md
+++ b/readme.md
@@ -100,7 +100,7 @@ Design Goals and Features
 * API with many handy functions
 * Memory efficient and performant
 * Loads data, "properties" metadata, and images from Tiled's TMX format
-* Supports base64, csv, gzip, zlib and uncompressed XML formats
+* Supports base64, csv, gzip, zlib, zstd and uncompressed XML formats
 * Properties for all native Tiled object types
 * Point data for polygon and polyline objects
 * Automatic flipping and rotation of tiles


### PR DESCRIPTION
Encountered a tilemap with zstd compression, easy enough to load and save it without but thought since there was a module on pip for [zstd](https://pypi.org/project/zstd/), might just add some optional support - if ``zstd`` is installed, then support decompression.