### PR TITLE
Parse if the <ellipse/> tag is set in object

### DIFF
--- a/pytmx/pytmx.py
+++ b/pytmx/pytmx.py
@@ -1508,6 +1508,7 @@ class TiledObject(TiledElement):
         self.closed = True
         self.template = None
         self.custom_types = custom_types
+        self.ellipse = False
 
         self.parse_xml(node)
 
@@ -1557,6 +1558,8 @@ class TiledObject(TiledElement):
         if polyline is not None:
             points = read_points(polyline.get("points"))
             self.closed = False
+
+        self.ellipse = node.find("ellipse") is not None
 
         if points:
             x1 = x2 = y1 = y2 = 0


### PR DESCRIPTION
It's currently not possible to see of an object is an ellipse. This is information that is available in the map. This PR adds the ellipse property to the object with value True when the ellipse tag exists in the object.